### PR TITLE
slog_common_event: Allow --help and --version even on unsupported platforms

### DIFF
--- a/src/slog_common_event.c
+++ b/src/slog_common_event.c
@@ -79,18 +79,6 @@ main(int argc, char **argv) {
 	servicelog *slog;
 	struct sl_event event;
 	uint64_t event_id;
-#ifndef SERVICELOG_TEST
-	int platform = 0;
-
-	platform = get_platform();
-	switch (platform) {
-	case PLATFORM_UNKNOWN:
-	case PLATFORM_POWERNV:
-		fprintf(stderr, "%s is not supported on the %s platform\n",
-				argv[0], __power_platform_name(platform));
-		exit(1);
-	}
-#endif
 
 	for (;;) {
 		option_index = 0;
@@ -138,6 +126,19 @@ main(int argc, char **argv) {
 			exit(1);
 		}
 	}
+
+#ifndef SERVICELOG_TEST
+	int platform = 0;
+
+	platform = get_platform();
+	switch (platform) {
+	case PLATFORM_UNKNOWN:
+	case PLATFORM_POWERNV:
+		fprintf(stderr, "%s is not supported on the %s platform\n",
+				argv[0], __power_platform_name(platform));
+		exit(1);
+	}
+#endif
 
 	if (e == NULL) {
 		if (verbose) {


### PR DESCRIPTION

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>


In Fedora and RHEL, we generate a manpage for `slog_common_event` by running `slog_common_event --help` and passing the result through [`help2man`](https://www.gnu.org/software/help2man/)

However, we recently discovered that some of our builders were failing. Upon inspection, it turned out that it's because if the builder happened to be PowerNV, `slog_common_event` throws an error instead of providing the help.

This patch moves the platform detection after the command-line parser so `--help` and `--version` are permitted to run even on PowerNV.