### PR TITLE
src/servicelog_switch: fix compiler warnings

### DIFF
--- a/src/servicelog_switch.c
+++ b/src/servicelog_switch.c
@@ -95,13 +95,15 @@ set_up_commands(void)
 		setup_failed("pathname lacks /");
 		exit(2);
 	}
+	pathlen -= (strlen(last_slash) - 1); /* account for trailing / */
 	last_slash[1] = '\0';
+
 	(void) strncpy(v1_cmd, self_dir, PATH_MAX - 1);
-	(void) strncat(v1_cmd, "v1_servicelog",
-		       (PATH_MAX - strlen(v1_cmd) - 1 ));
+	v1_cmd[pathlen] = '\0';
+	(void) strncat(v1_cmd, "v1_servicelog", (PATH_MAX - pathlen - 1 ));
 	(void) strncpy(v29_cmd, self_dir, PATH_MAX - 1);
-	(void) strncat(v29_cmd, "v29_servicelog",
-		       (PATH_MAX - strlen(v29_cmd) - 1));
+	v29_cmd[pathlen] = '\0';
+	(void) strncat(v29_cmd, "v29_servicelog", (PATH_MAX - pathlen - 1));
 }
 
 static void


### PR DESCRIPTION
Fix the compile warning see with GCC-11:

src/servicelog_switch.c: In function 'set_up_commands':
src/servicelog_switch.c:99:16: warning: 'strncpy' output may be truncated copying 4095 bytes from a string of length 4095 [-Wstringop-truncation]
   99 |         (void) strncpy(v1_cmd, self_dir, PATH_MAX - 1);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/servicelog_switch.c:102:16: warning: 'strncpy' output may be truncated copying 4095 bytes from a string of length 4095 [-Wstringop-truncation]
  102 |         (void) strncpy(v29_cmd, self_dir, PATH_MAX - 1);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

keep the GCC happy with manually terminating the string.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.ibm.com>